### PR TITLE
Update FogLooksGoodNowConfig.java

### DIFF
--- a/src/main/java/net/shizotoaster/foglooksmodernnow/config/FogLooksGoodNowConfig.java
+++ b/src/main/java/net/shizotoaster/foglooksmodernnow/config/FogLooksGoodNowConfig.java
@@ -50,7 +50,7 @@ public class FogLooksGoodNowConfig {
         List<? extends String> densityConfigs = CLIENT_CONFIG.biomeFogs.get();
 
         for (String densityConfig : densityConfigs) {
-            String[] options = densityConfig.split(".*");
+            String[] options = densityConfig.split(",");
             try {
                 list.add(Pair.of(options[0], new FogManager.BiomeFogDensity(Float.parseFloat(options[1]), Float.parseFloat(options[2]), Integer.parseInt(options[3]))));
             } catch (NumberFormatException e) {


### PR DESCRIPTION
changed the regex in the biome fog density map function, which allows the final config line to not crash the game even when used properly. i'm also just realizing that the last number probably does work (unlike what i posited in a recent issue comment), but i've been mixing up cave fog with normal biome fog. whoops!